### PR TITLE
Revert "[utils] Use "-" as id separator instead of "_""

### DIFF
--- a/utils/idprovider.go
+++ b/utils/idprovider.go
@@ -41,7 +41,7 @@ func CreateID(prefix string) (string, error) {
 		return "", aoserrors.Wrap(err)
 	}
 
-	return prefix + "-" + id, nil
+	return prefix + "_" + id, nil
 }
 
 /***********************************************************************************************************************


### PR DESCRIPTION
This reverts commit 8fae9fe6d1645c47032057c7a749e48830235050.